### PR TITLE
feat: 'Request a topic' button + GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -1,0 +1,34 @@
+name: Request Information
+description: Ask me to cover a topic or add something to the site.
+title: "[Request] "
+labels: ["request"]
+body:
+  - type: dropdown
+    id: subject
+    attributes:
+      label: Subject
+      description: What area does this relate to?
+      options:
+        - General
+        - Supplements
+        - Exercise
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: What would you like to know?
+      description: Be as specific as you'd like — a supplement, a protocol, a question you have, anything.
+      placeholder: "e.g., What do you think about vitamin D? Is there a best time to take fish oil?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Any context? (optional)
+      description: Anything else that might help — your goals, current routine, where you heard about it, etc.
+      placeholder: "e.g., I saw an ad for this on Instagram and wanted to know if it's legit."
+    validations:
+      required: false

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -487,6 +487,35 @@
       color: var(--text-secondary);
     }
 
+    /* ── Request Button ── */
+    .request-bar {
+      text-align: center;
+      margin-top: 20px;
+      position: relative;
+      z-index: 1;
+    }
+
+    .request-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 10px 20px;
+      border-radius: 999px;
+      background: var(--card-bg);
+      color: var(--accent);
+      font-size: 0.82rem;
+      font-weight: 500;
+      text-decoration: none;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
+      transition: all 0.2s ease;
+    }
+
+    .request-link:hover {
+      background: var(--accent);
+      color: #fff;
+      box-shadow: 0 6px 16px rgba(46, 125, 82, 0.20);
+    }
+
     /* ── Mobile ── */
     @media (max-width: 480px) {
       body {
@@ -544,6 +573,12 @@
         </div>
       </section>
       {% endfor %}
+    </div>
+
+    <div class="request-bar">
+      <a href="https://github.com/Jherrild/herrild_health/issues/new?template=request.yml"
+         target="_blank"
+         class="request-link">💬 Request a topic</a>
     </div>
 
     <footer class="site-footer">


### PR DESCRIPTION
Adds a way for site visitors to request new content:

- **Issue template** (`.github/ISSUE_TEMPLATE/request.yml`) with subject dropdown (General/Supplements/Exercise), details field, and optional context
- **Request button** — `💬 Request a topic` pill lives below the tab content, always visible regardless of which tab is active
- Links directly to the issue form with template pre-selected
- Blank issues disabled to keep requests structured

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>