### PR TITLE
fix: auto-assign requests to Jherrild, update dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/request.yml
+++ b/.github/ISSUE_TEMPLATE/request.yml
@@ -2,6 +2,8 @@ name: Request Information
 description: Ask me to cover a topic or add something to the site.
 title: "[Request] "
 labels: ["request"]
+assignees:
+  - Jherrild
 body:
   - type: dropdown
     id: subject
@@ -9,9 +11,9 @@ body:
       label: Subject
       description: What area does this relate to?
       options:
-        - General
         - Supplements
         - Exercise
+        - Other
     validations:
       required: true
 


### PR DESCRIPTION
- Auto-assigns new request issues to @Jherrild
- Dropdown reordered: Supplements, Exercise, Other

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>